### PR TITLE
URL Upload

### DIFF
--- a/lib/src/api_client/cloudinary_api_client.dart
+++ b/lib/src/api_client/cloudinary_api_client.dart
@@ -85,13 +85,13 @@ class CloudinaryApiClient extends CloudinaryApi {
     params['file'] = fileBytes != null
         ? MultipartFile.fromBytes(
             fileBytes,
-            filename:
-                fileName ?? DateTime.now().millisecondsSinceEpoch.toString(),
+            filename: fileName ?? DateTime.now().millisecondsSinceEpoch.toString(),
           )
-        : await MultipartFile.fromFile(file!, filename: fileName);
+        : (file!.startsWith('http://') || file.startsWith('https://'))
+            ? file
+            : await MultipartFile.fromFile(file, filename: fileName);
     params['timestamp'] = timeStamp;
-    params['signature'] =
-        getSignature(secret: apiSecret, timeStamp: timeStamp, params: params);
+    params['signature'] = getSignature(secret: apiSecret, timeStamp: timeStamp, params: params);
 
     var formData = FormData.fromMap(params);
 
@@ -154,8 +154,7 @@ class CloudinaryApiClient extends CloudinaryApi {
 
     final params = <String, dynamic>{
       'upload_preset': uploadPreset,
-      if (publicId != null || fileName != null)
-        'public_id': publicId ?? fileName,
+      if (publicId != null || fileName != null) 'public_id': publicId ?? fileName,
       if (folder != null) 'folder': folder,
 
       /// Setting the optParams... this would override the public_id and folder
@@ -165,9 +164,10 @@ class CloudinaryApiClient extends CloudinaryApi {
 
     params['file'] = fileBytes != null
         ? MultipartFile.fromBytes(fileBytes,
-            filename:
-                fileName ?? DateTime.now().millisecondsSinceEpoch.toString())
-        : await MultipartFile.fromFile(file!, filename: fileName);
+            filename: fileName ?? DateTime.now().millisecondsSinceEpoch.toString())
+        : (file!.startsWith('http://') || file.startsWith('https://'))
+            ? file
+            : await MultipartFile.fromFile(file, filename: fileName);
 
     var formData = FormData.fromMap(params);
 
@@ -223,8 +223,7 @@ class CloudinaryApiClient extends CloudinaryApi {
     params['public_id'] = publicId;
     params['api_key'] = apiKey;
     params['timestamp'] = timeStamp;
-    params['signature'] =
-        getSignature(secret: apiSecret, timeStamp: timeStamp, params: params);
+    params['signature'] = getSignature(secret: apiSecret, timeStamp: timeStamp, params: params);
 
     var formData = FormData.fromMap(params);
 
@@ -232,8 +231,7 @@ class CloudinaryApiClient extends CloudinaryApi {
     CloudinaryResponse cloudinaryResponse;
     int? statusCode;
     try {
-      response =
-          await post('$cloudName/${resourceType.name}/destroy', data: formData);
+      response = await post('$cloudName/${resourceType.name}/destroy', data: formData);
       statusCode = response.statusCode;
       cloudinaryResponse = CloudinaryResponse.fromJsonMap(response.data);
     } catch (error, stacktrace) {


### PR DESCRIPTION
The cloudinary `upload` endpoints actually allow `file` to be a URL for remote upload: https://cloudinary.com/documentation/upload_images#upload_from_a_remote_url

This PR allows the `file` param to be a URL - if the string starts with `http://` or `https://`, it is just passed as a string instead of being converted to a local path.